### PR TITLE
Fix: html, body 태그의 justify-self 중복 선언으로 인한 브라우저별 레이아웃 차이 문제 해결

### DIFF
--- a/src/components/mocules/company/NoticeRole.tsx
+++ b/src/components/mocules/company/NoticeRole.tsx
@@ -202,7 +202,7 @@ const RoleItemsWrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-top: 10px;
+  /* margin-top: 10px; */
 `;
 
 const ButtonWrapper = styled.div`

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
 *,
 body,
 :root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+
   margin: 0;
   padding: 0;
   box-sizing: border-box;
@@ -10,16 +12,16 @@ body,
   --__scheduledItemHeigth: 17px;
 }
 
-html,
 body {
   height: 100%;
   overflow-x: hidden;
   max-width: 460px;
-  justify-self: center;
+  /* justify-self: center; */
 }
 
 html {
   width: 100vw;
+  /* justify-self: center; */
 }
 
 :root {


### PR DESCRIPTION
## 문제 상황
브라우저별로 화면이 다르게 렌더링되는 문제 발생:

### Chrome, Edge
- `display: grid` 명시적 선언 없이도 `justify-self: center` 동작
- 브라우저가 내부적으로 grid 컨텍스트 제공
- html, body 태그에 `justify-self: center` 중복 적용으로 화면이 460px보다 좁게 표시
<img width="1440" height="900" alt="chorme" src="https://github.com/user-attachments/assets/845f4c78-716f-4c25-954f-d24d11761547" />
<img width="1440" height="900" alt="edge" src="https://github.com/user-attachments/assets/42ce3031-a272-4591-a092-03fdc8a8e2fe" />

### Safari, Firefox
- `display: grid` 선언 없어 `justify-self: center` 미동작
- body가 460px 너비로 왼쪽에 치우쳐 표시

<img width="1440" height="900" alt="firefox" src="https://github.com/user-attachments/assets/04920dd0-4330-4c52-a922-e420c6bd8f1d" />

<img width="1440" height="900" alt="safari" src="https://github.com/user-attachments/assets/f0fcc147-91db-46a1-b0e5-c2752b153b32" />


## 해결 방법
- html, body 태그에서 `justify-self: center` 속성 제거
- 각 컴포넌트는 이미 Container component로 감싸져 정중앙 배치되므로 불필요한 속성이었음
- 모든 브라우저에서 일관된 레이아웃 동작 보장

## 변경사항
```css
/* 제거된 코드 */
html, body {
  justify-self: center; /* 삭제 */
}
```

---
관련 이슈: 브라우저별 CSS Grid 구현 차이로 인한 레이아웃 불일치

## ✨ Issue Number

- close

## 🗂️ Details

- [ ] TODO
- [ ] TODO
